### PR TITLE
Add support for "smart updates" of filters. Add smart update of unload event.

### DIFF
--- a/lib/Model/filter.js
+++ b/lib/Model/filter.js
@@ -3,6 +3,8 @@ var Model = require('./Model');
 var defaultFns = require('./defaultFns');
 
 Model.INITS.push(function(model) {
+  var smartUpdates = ['unload'];
+
   model.root._filters = new Filters(model);
   model.on('all', filterListener);
   function filterListener(segments, eventArgs) {
@@ -15,7 +17,14 @@ Model.INITS.push(function(model) {
         util.mayImpact(filter.segments, segments) ||
         (filter.inputsSegments && util.mayImpactAny(filter.inputsSegments, segments))
       ) {
-        filter.update(pass);
+        var method = eventArgs[0];
+        if(smartUpdates.indexOf(method) > -1) {
+          // Do smart update which tries to limit the execution needed
+          filter._smartUpdate(pass, method, eventArgs, segments);
+        } else {
+          // Do regular update which reruns everything
+          filter.update(pass);
+        }
       }
     }
   }
@@ -238,6 +247,23 @@ Filter.prototype.get = function() {
 
 Filter.prototype.update = function(pass) {
   var ids = this.ids();
+  this.model.pass(pass, true)._setArrayDiff(this.idsSegments, ids);
+};
+
+Filter.prototype._smartUpdate = function(pass, method, eventArgs, segments) {
+  var ids = this.model._get(this.idsSegments) || [];
+
+  if(method === 'unload') {
+    var doc = eventArgs[1];
+    var id = doc.id;
+    var pos = ids.indexOf(id);
+
+    // If it was already filtered, we ain't need to do anything
+    if(pos < 0) return;
+
+    ids.splice(pos, 1);
+  }
+
   this.model.pass(pass, true)._setArrayDiff(this.idsSegments, ids);
 };
 


### PR DESCRIPTION
Assume the following scenario:
1) You have a lot of docs of collection1 loaded on page 1
2) You go to page where you setup a filter based upon collection1

Due to the unload delay in Racer and how filters work (basically, rerun everything on every little event), you'll end up with perf problems if you have the above scenario. Specifically, we had a simple scenario where we'd have a significant amount of docs (100-1000) unloading, which caused a lot of reruns of the ids fn. This caused the browser to hang.
